### PR TITLE
Optimize - independent from target-lexicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["rustup", "target", "toolchain"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-target-lexicon = { version = "0.12", features = ["serde_support"] }
 thiserror = "1.0"
 strip-ansi-escapes = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-This crate provides a simple interface to the `rustup target` command for listing and adding targets.
-It uses the [target-lexicon](https://crates.io/crates/target-lexicon) Triple to identify targets.
+# Rustup Configurator
+
+This crate provides a simple interface to the `rustup target` command for listing and adding targets in Rust. It's designed to make managing your Rust targets easier and more efficient.
+
+## Usage
 
 ```rust
-use rustup_configurator::Triple;
+use rustup_configurator::target::Target;
 
-// get a list of all targets and if they are installed
-let list: Vec<(Triple, bool)> = rustup_configurator::list().unwrap();
+// Get a list of all targets and if they are installed
+let list: Vec<Target> = rustup_configurator::target::list().unwrap();
 
-// get all installed targets
-let installed: Vec<Triple> = rustup_configurator::installed().unwrap();
+// Get all installed targets
+let installed: Vec<Target> = rustup_configurator::target::installed().unwrap();
 
-// install some targets
-rustup_configurator::install(&["aarch64-apple-ios".parse().unwrap()]).unwrap();
-```
-
+// Install some targets
+rustup_configurator::target::install(&["aarch64-apple-ios".into()]).unwrap();
 # Contributions
+```
 
 Contributions are welcome! Please open an issue or PR on [GitHub](https://github.com/akesson/rustup-configurator)

--- a/examples/targets.rs
+++ b/examples/targets.rs
@@ -1,0 +1,14 @@
+use rustup_configurator::target::Target;
+
+fn main() {
+    // Get a list of all targets and if they are installed
+    let list: Vec<Target> = rustup_configurator::target::list().unwrap();
+    println!("All targets: \n{:#?}", list);
+
+    // Get all installed targets
+    let installed: Vec<Target> = rustup_configurator::target::installed().unwrap();
+    println!("Installed targets: \n{:#?}", installed);
+
+    // Install some targets
+    rustup_configurator::target::install(&["aarch64-apple-ios".into()]).unwrap();
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,10 +10,4 @@ pub enum RustupTargetError {
         stderr: String,
         stdout: String,
     },
-    #[error("Rustup returned an invalid triple '{line}' due to '{source}', please raise an issue at: https://github.com/akesson/rustup-target/issues")]
-    InvalidRustupTriple {
-        line: String,
-        #[source]
-        source: target_lexicon::ParseError,
-    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! let installed: Vec<Target> = rustup_configurator::target::installed().unwrap();
 //!
 //! // install some targets
-//! rustup_configurator::target::install(&["aarch64-apple-ios".parse().unwrap()]).unwrap();
+//! rustup_configurator::target::install(&["aarch64-apple-ios".into()]).unwrap();
 //! ```
 mod error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,66 +2,22 @@
 //! It uses the [target-lexicon](https://crates.io/crates/target-lexicon) Triple to identify targets.
 //!
 //! ```rust
-//! use rustup_configurator::Triple;
+//! use rustup_configurator::target::Target;
 //!
 //! // get a list of all targets and if they are installed
-//! let list: Vec<(Triple, bool)> = rustup_configurator::list().unwrap();
+//! let list: Vec<Target> = rustup_configurator::target::list().unwrap();
 //!
 //! // get all installed targets
-//! let installed: Vec<Triple> = rustup_configurator::installed().unwrap();
+//! let installed: Vec<Target> = rustup_configurator::target::installed().unwrap();
 //!
 //! // install some targets
-//! rustup_configurator::install(&["aarch64-apple-ios".parse().unwrap()]).unwrap();
+//! rustup_configurator::target::install(&["aarch64-apple-ios".parse().unwrap()]).unwrap();
 //! ```
 mod error;
 
-use std::{process::Command, str::FromStr};
-
 pub use error::RustupTargetError;
 
-// re-exported Triple
-pub use target_lexicon::Triple;
-
-/// List all available rust targets using the `rustup target list` command
-///
-/// Returns a list of targets triples and a bool indicating if the target is installed
-pub fn list() -> Result<Vec<(Triple, bool)>, RustupTargetError> {
-    let output = Command::new("rustup")
-        .arg("target")
-        .arg("list")
-        .output()
-        .map_err(RustupTargetError::ProcessFailed)?;
-
-    let out = extract_stdout(&output)?;
-
-    parse_rustup_triple_list(&out)
-}
-
-/// List all installed rust targets using the `rustup target list` command
-///
-/// Returns a list of targets triples and a bool indicating if the target is installed
-pub fn installed() -> Result<Vec<Triple>, RustupTargetError> {
-    Ok(list()?
-        .into_iter()
-        .filter(|(_, inst)| *inst)
-        .map(|(t, _)| t)
-        .collect())
-}
-
-/// Install a list of rust targets, using the `rustup target add` command
-pub fn install(list: &[Triple]) -> Result<(), RustupTargetError> {
-    let mut cmd = Command::new("rustup");
-    cmd.arg("target").arg("add");
-    for triple in list {
-        cmd.arg(triple.to_string());
-    }
-    let output = cmd.output().map_err(RustupTargetError::ProcessFailed)?;
-
-    // just making sure that no error was returned
-    let _out = extract_stdout(&output)?;
-
-    Ok(())
-}
+pub mod target;
 
 fn extract_stdout(output: &std::process::Output) -> Result<String, RustupTargetError> {
     let cleaned = strip_ansi_escapes::strip(&output.stdout);
@@ -76,68 +32,4 @@ fn extract_stdout(output: &std::process::Output) -> Result<String, RustupTargetE
         });
     }
     Ok(out)
-}
-
-fn parse_rustup_triple_list(list: &str) -> Result<Vec<(Triple, bool)>, RustupTargetError> {
-    let mut triples = Vec::new();
-    for mut line in list.lines() {
-        let installed = if line.ends_with(" (installed)") {
-            line = &line[..line.len() - 12];
-            true
-        } else {
-            false
-        };
-        // the Triple parsing of "wasm32-wasi-preview1-threads" fails
-        // so we just skip it here.
-        if line.contains("preview") {
-            continue;
-        }
-        let triple = match Triple::from_str(line) {
-            Err(e) => {
-                return Err(RustupTargetError::InvalidRustupTriple {
-                    line: line.to_string(),
-                    source: e,
-                })
-            }
-            Ok(t) => t,
-        };
-        triples.push((triple, installed));
-    }
-    Ok(triples)
-}
-
-#[test]
-fn test_parse_list() {
-    let list = r###"aarch64-apple-darwin (installed)
-aarch64-apple-ios (installed)
-aarch64-apple-ios-sim (installed)
-aarch64-fuchsiaarch64-linux-android (installed)
-aarch64-pc-windows-msvc"###;
-
-    let triples = parse_rustup_triple_list(list).unwrap();
-
-    let re_composed = triples
-        .iter()
-        .map(|(t, inst)| format!("{t} - installed: {inst:?}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    insta::assert_snapshot!(re_composed, @r###"
-    aarch64-apple-darwin - installed: true
-    aarch64-apple-ios - installed: true
-    aarch64-apple-ios-sim - installed: true
-    aarch64-fuchsiaarch64-linux-android - installed: true
-    aarch64-pc-windows-msvc - installed: false
-    "###
-    );
-}
-
-#[test]
-fn test_parse_list_wrong_arch() {
-    let list = r###"aarch64-apple-darwin (installed)
-arch64-apple-ios (installed)
-aarch64-pc-windows-msvc"###;
-
-    let err = parse_rustup_triple_list(list).unwrap_err();
-    insta::assert_snapshot!(err.to_string(), 
-    @"Rustup returned an invalid triple 'arch64-apple-ios' due to 'Unrecognized architecture: arch64', please raise an issue at: https://github.com/akesson/rustup-target/issues");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-//! This crate provides a simple interface to the rustup target command for listing and adding targets.
-//! It uses the [target-lexicon](https://crates.io/crates/target-lexicon) Triple to identify targets.
+//! This crate provides a simple interface to the rustup target command for listing and adding targets. 
 //!
 //! ```rust
 //! use rustup_configurator::target::Target;

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,153 @@
+use std::{process::Command, str::FromStr};
+
+use crate::{extract_stdout, RustupTargetError};
+
+#[derive(Debug)]
+pub struct Target {
+    pub triple: TargetTriple,
+    pub installed: bool,
+}
+
+#[derive(Debug)]
+pub enum TargetTriple {
+    Conied(target_lexicon::Triple),
+    Uncoined(String),
+}
+
+impl FromStr for TargetTriple {
+    type Err = target_lexicon::ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match target_lexicon::Triple::from_str(s) {
+            Ok(triple) => Ok(TargetTriple::Conied(triple)),
+            Err(_) => Ok(TargetTriple::Uncoined(s.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for TargetTriple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TargetTriple::Conied(triple) => write!(f, "{}", triple),
+            TargetTriple::Uncoined(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl std::fmt::Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} - installed: {}", self.triple, self.installed)
+    }
+}
+
+/// List all available rust targets using the `rustup target list` command
+///
+/// Returns a list of targets triples and a bool indicating if the target is installed
+pub fn list() -> Result<Vec<Target>, RustupTargetError> {
+    let output = Command::new("rustup")
+        .arg("target")
+        .arg("list")
+        .output()
+        .map_err(RustupTargetError::ProcessFailed)?;
+
+    let out = extract_stdout(&output)?;
+
+    parse_rustup_triple_list(&out)
+}
+
+/// List all installed rust targets using the `rustup target list` command
+///
+/// Returns a list of targets triples and a bool indicating if the target is installed
+pub fn installed() -> Result<Vec<Target>, RustupTargetError> {
+    let output = Command::new("rustup")
+        .arg("target")
+        .arg("list")
+        .arg("--installed")
+        .output()
+        .map_err(RustupTargetError::ProcessFailed)?;
+    let out = extract_stdout(&output)?;
+
+    parse_rustup_triple_list(&out)
+}
+
+/// Install a list of rust targets, using the `rustup target add` command
+pub fn install(list: &[target_lexicon::Triple]) -> Result<(), RustupTargetError> {
+    let mut cmd = Command::new("rustup");
+    cmd.arg("target").arg("add");
+    for triple in list {
+        cmd.arg(triple.to_string());
+    }
+    let output = cmd.output().map_err(RustupTargetError::ProcessFailed)?;
+
+    // just making sure that no error was returned
+    let _out = extract_stdout(&output)?;
+
+    Ok(())
+}
+
+fn parse_rustup_triple_list(list: &str) -> Result<Vec<Target>, RustupTargetError> {
+    let mut targets = Vec::new();
+    for mut line in list.lines() {
+        let installed = if line.ends_with(" (installed)") {
+            line = &line[..line.len() - 12];
+            true
+        } else {
+            false
+        };
+        // the Triple parsing of "wasm32-wasi-preview1-threads" fails
+        // so we just skip it here.
+        if line.contains("preview") {
+            continue;
+        }
+        let triple = match TargetTriple::from_str(line) {
+            Err(e) => {
+                return Err(RustupTargetError::InvalidRustupTriple {
+                    line: line.to_string(),
+                    source: e,
+                })
+            }
+            Ok(t) => t,
+        };
+        targets.push(Target { triple, installed });
+    }
+    Ok(targets)
+}
+
+#[test]
+fn test_parse_list() {
+    let list = r###"aarch64-apple-darwin (installed)
+aarch64-apple-ios (installed)
+aarch64-apple-ios-sim (installed)
+aarch64-fuchsiaarch64-linux-android (installed)
+aarch64-pc-windows-msvc"###;
+
+    let triples = parse_rustup_triple_list(list).unwrap();
+
+    let re_composed = triples
+        .iter()
+        .map(|t| format!("{t}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    insta::assert_snapshot!(re_composed, @r###"
+    aarch64-apple-darwin - installed: true
+    aarch64-apple-ios - installed: true
+    aarch64-apple-ios-sim - installed: true
+    aarch64-fuchsiaarch64-linux-android - installed: true
+    aarch64-pc-windows-msvc - installed: false
+    "###
+    );
+}
+
+#[test]
+fn test_parse_list_uncoind_arch() {
+    let list = r###"aarch64-apple-darwin (installed)
+arch64-apple-ios (installed)
+aarch64-pc-windows-msvc"###;
+
+    let parsed_list = parse_rustup_triple_list(list).unwrap();
+    let formated_list = format!("{:?}", parsed_list);
+
+    insta::assert_snapshot!(formated_list, @r###"
+    [Target { triple: Conied(Triple { architecture: Aarch64(Aarch64), vendor: Apple, operating_system: Darwin, environment: Unknown, binary_format: Macho }), installed: true }, Target { triple: Uncoined("arch64-apple-ios"), installed: true }, Target { triple: Conied(Triple { architecture: Aarch64(Aarch64), vendor: Pc, operating_system: Windows, environment: Msvc, binary_format: Coff }), installed: false }]
+    "###
+    );
+}


### PR DESCRIPTION
Try to avoid issue #1.

Since the `rustup-configurator` does not parse any user-generated target-triple, and all the triples come from rustup itself, it may not be necessary to identify the triple, as we can assume it is always valid currently.

- For `rustup_configurator::target::install` function, we could just let the rustup do the error check thing.

- For other future use cases, we could add a feature involving `target-lexicon` again to help users identify the triple in another error-proof way.